### PR TITLE
fix: custom 500s timeout on predict request

### DIFF
--- a/predict.go
+++ b/predict.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"time"
 )
 
 // PredictResult struct storing predictions result

--- a/predict.go
+++ b/predict.go
@@ -134,7 +134,8 @@ func Predict(host string, predictRequest *PredictRequest) (result PredictResult,
 	req.Header.Set("Content-Type", "application/json")
 
 	// Execute request
-	resp, err := httpClient.Do(req)
+	client := http.Client{Timeout: 500 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
New `tensorrt` deepdetect backend requires a longer timeout on the first predict. Default Go `net/http httpClient` timeout is not enough for this request.